### PR TITLE
use of profiles to exclude interface service from automatically running

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -57,7 +57,7 @@ It also builds the Namada Browser extension during the startup. The chain ID is 
 You can tweak supported environment variables through the `.env` file.    
 Building cloud take a very long time to finish, so be patient, in the meantime you can work with the CLI.    
 ```shell
-docker compose up -d interface
+docker compose --profile interface up -d
 ```
 ## Using the Interface
 When the container is ready you can access the Interface in your browser, the default address is http://localhost:3000/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,8 +55,10 @@ services:
     ports:
       - "26656" # p2p
       - "26657" # http rpc
+
   interface:
     restart: unless-stopped
+    profiles: ["interface"]
     build:
       dockerfile: docker/namada-interface.Dockerfile
       context: .


### PR DESCRIPTION
we should be able to distinguish easily between running the validators and running the interface.  this is done with profiles.  perhaps we could consider having a profile for the validators too but by default it's what we're interested in